### PR TITLE
Add hbs, handlebars as markup syntax languages

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -8,7 +8,7 @@ import {
 } from "vscode-languageserver/node";
 
 const syntaxes = {
-  markup: ["html", "xml", "xsl", "jsx", "js", "pug", "slim", "haml"],
+  markup: ["html", "xml", "xsl", "jsx", "js", "pug", "slim", "haml", "hbs", "handlebars"],
   stylesheet: ["css", "sass", "scss", "less", "sss", "stylus"],
 };
 


### PR DESCRIPTION
Hey I am pretty new neovim and language servers. 
I was trying to setyp emmet + nvim-cmp for quite some time now, and still having problems. The `emmet_ls` project just don't work properly. Your server doing good job on working with cmp, but can we add `hbs` as well ? 

Let me know what else needs to be done  to get this done